### PR TITLE
Use NewWithRegion not minio's region resolution

### DIFF
--- a/pkg/s3/s3-client.go
+++ b/pkg/s3/s3-client.go
@@ -41,7 +41,7 @@ func newS3Client(cfg *Config) (*s3Client, error) {
 	if u.Port() != "" {
 		endpoint = u.Hostname() + ":" + u.Port()
 	}
-	minioClient, err := minio.New(endpoint, client.cfg.AccessKeyID, client.cfg.SecretAccessKey, ssl)
+	minioClient, err := minio.NewWithRegion(endpoint, client.cfg.AccessKeyID, client.cfg.SecretAccessKey, ssl, client.cfg.Region)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This fixes behaviour for providers that don't have S3's standard regions (like Scaleway, which has `nl-ams` as a region). Minio, using `New`, only uses regions like `us-east-1`.

I don't know whether this will act correctly if you don't set the region in the secret - probably need a little logic to check if it exists and use `New` if not. I would do it but this is honestly the first line of go that I've ever written and I don't want to screw it up 😰