### PR TITLE
Adding ability to specify uid/gid when using goofys.

### DIFF
--- a/deploy/kubernetes/storageclass.yaml
+++ b/deploy/kubernetes/storageclass.yaml
@@ -8,6 +8,14 @@ parameters:
   # specify which mounter to use
   # can be set to rclone, s3fs, goofys or s3backer
   mounter: rclone
+
+  # goofys allows the following additional optional parameters to be passed
+  
+  # The uid to mount the volume as.
+  # goofysuid: "1000"
+  # The gid to mount the volume as.
+  # goofysgid: "1000"
+
   csi.storage.k8s.io/provisioner-secret-name: csi-s3-secret
   csi.storage.k8s.io/provisioner-secret-namespace: kube-system
   csi.storage.k8s.io/controller-publish-secret-name: csi-s3-secret

--- a/pkg/s3/mounter.go
+++ b/pkg/s3/mounter.go
@@ -14,7 +14,7 @@ import (
 type Mounter interface {
 	Stage(stagePath string) error
 	Unstage(stagePath string) error
-	Mount(source string, target string) error
+	Mount(source string, target string, attrib map[string]string) error
 }
 
 const (

--- a/pkg/s3/mounter_rclone.go
+++ b/pkg/s3/mounter_rclone.go
@@ -36,7 +36,7 @@ func (rclone *rcloneMounter) Unstage(stageTarget string) error {
 	return nil
 }
 
-func (rclone *rcloneMounter) Mount(source string, target string) error {
+func (rclone *rcloneMounter) Mount(source string, target string, attrib map[string]string) error {
 	args := []string{
 		"mount",
 		fmt.Sprintf(":s3:%s/%s", rclone.bucket.Name, rclone.bucket.FSPath),

--- a/pkg/s3/mounter_s3backer.go
+++ b/pkg/s3/mounter_s3backer.go
@@ -81,7 +81,7 @@ func (s3backer *s3backerMounter) Unstage(stageTarget string) error {
 	return fuseUnmount(stageTarget)
 }
 
-func (s3backer *s3backerMounter) Mount(source string, target string) error {
+func (s3backer *s3backerMounter) Mount(source string, target string, attrib map[string]string) error {
 	device := path.Join(source, s3backerDevice)
 	// second mount will mount the 'file' as a filesystem
 	err := mount.New("").Mount(device, target, s3backerFsType, []string{})

--- a/pkg/s3/mounter_s3fs.go
+++ b/pkg/s3/mounter_s3fs.go
@@ -34,7 +34,7 @@ func (s3fs *s3fsMounter) Unstage(stageTarget string) error {
 	return nil
 }
 
-func (s3fs *s3fsMounter) Mount(source string, target string) error {
+func (s3fs *s3fsMounter) Mount(source string, target string, attrib map[string]string) error {
 	if err := writes3fsPass(s3fs.pwFileContent); err != nil {
 		return err
 	}

--- a/pkg/s3/nodeserver.go
+++ b/pkg/s3/nodeserver.go
@@ -89,7 +89,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	if err != nil {
 		return nil, err
 	}
-	if err := mounter.Mount(stagingTargetPath, targetPath); err != nil {
+	if err := mounter.Mount(stagingTargetPath, targetPath, attrib); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
With this change, while setting up your StorageClass, you can specify the
uid and gid that goofys should use when mounting your file system. These
two new options are goofysuid and goofysgid.

This helps with #21 however it doesn't allow specifying specific directory or file permissions for the mounted volume.