### PR TITLE
feat: make it compatible to k3s v1.19.5+k3s2 and newer k8s

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This is still very experimental and should not be used in any production environ
 apiVersion: v1
 kind: Secret
 metadata:
+  namespace: kube-system
   name: csi-s3-secret
 stringData:
   accessKeyID: <YOUR_ACCESS_KEY_ID>

--- a/deploy/kubernetes/attacher.yaml
+++ b/deploy/kubernetes/attacher.yaml
@@ -54,11 +54,14 @@ spec:
       port: 12345
 ---
 kind: StatefulSet
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 metadata:
   name: csi-attacher-s3
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      app: "csi-attacher-s3"
   serviceName: "csi-attacher-s3"
   replicas: 1
   template:

--- a/deploy/kubernetes/csi-s3.yaml
+++ b/deploy/kubernetes/csi-s3.yaml
@@ -39,7 +39,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: DaemonSet
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 metadata:
   name: csi-s3
   namespace: kube-system

--- a/deploy/kubernetes/provisioner.yaml
+++ b/deploy/kubernetes/provisioner.yaml
@@ -53,11 +53,14 @@ spec:
       port: 12345
 ---
 kind: StatefulSet
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 metadata:
   name: csi-provisioner-s3
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      app: "csi-provisioner-s3"
   serviceName: "csi-provisioner-s3"
   replicas: 1
   template:

--- a/deploy/kubernetes/secret.yaml.sample
+++ b/deploy/kubernetes/secret.yaml.sample
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
+  namespace: kube-system
   name: csi-s3-secret
 stringData:
   accessKeyID: <YOUR_ACCESS_KEY_ID>


### PR DESCRIPTION
fix: https://github.com/ctrox/csi-s3/issues/35
fix: example secret is not created under `kube-system` namespace by default in README

Signed-off-by: Toby Yan <me@tobyan.com>