### PR TITLE
use csi-provisioner:v2.1.0, provider and attacher will only run in master node

### DIFF
--- a/deploy/kubernetes/attacher.yaml
+++ b/deploy/kubernetes/attacher.yaml
@@ -50,8 +50,8 @@ spec:
   selector:
     app: csi-attacher-s3
   ports:
-    - name: dummy
-      port: 12345
+    - name: csi-s3-dummy
+      port: 65535
 ---
 kind: StatefulSet
 apiVersion: apps/v1
@@ -73,6 +73,9 @@ spec:
         app: csi-attacher-s3
     spec:
       serviceAccount: csi-attacher-sa
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: "Exists"
       containers:
         - name: csi-attacher
           image: quay.io/k8scsi/csi-attacher:v2.2.0

--- a/deploy/kubernetes/provisioner.yaml
+++ b/deploy/kubernetes/provisioner.yaml
@@ -49,8 +49,8 @@ spec:
   selector:
     app: csi-provisioner-s3
   ports:
-    - name: dummy
-      port: 12345
+    - name: csi-s3-dummy
+      port: 65535
 ---
 kind: StatefulSet
 apiVersion: apps/v1
@@ -72,11 +72,13 @@ spec:
         app: csi-provisioner-s3
     spec:
       serviceAccount: csi-provisioner-sa
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: "Exists"
       containers:
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.3.1
+          image: quay.io/k8scsi/csi-provisioner:v2.1.0
           args:
-            - "--provisioner=ch.ctrox.csi.s3-driver"
             - "--csi-address=$(ADDRESS)"
             - "--v=4"
           env:
@@ -88,7 +90,6 @@ spec:
               mountPath: /var/lib/kubelet/plugins/ch.ctrox.csi.s3-driver
         - name: csi-s3
           image: ctrox/csi-s3:dev
-          imagePullPolicy: Never
           args:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--nodeid=$(NODE_ID)"


### PR DESCRIPTION
Use csi-provisioner:v2.1.0 , will fixed #44 

I use DigitalOcean spaces as S3 storage,  it's not support removeObjects api, I'll patch it later.