### PR TITLE
Clear .passwd-s3fs before write new AccessKey & SecretKey

### DIFF
--- a/pkg/mounter/s3fs.go
+++ b/pkg/mounter/s3fs.go
@@ -55,7 +55,7 @@ func (s3fs *s3fsMounter) Mount(source string, target string) error {
 
 func writes3fsPass(pwFileContent string) error {
 	pwFileName := fmt.Sprintf("%s/.passwd-s3fs", os.Getenv("HOME"))
-	pwFile, err := os.OpenFile(pwFileName, os.O_RDWR|os.O_CREATE, 0600)
+	pwFile, err := os.OpenFile(pwFileName, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Two Storage Class, with different s3 cluster, so different AccessKey & SecretKey.
The second s3 cluster cannot mount. Because of .passwd-s3fs is not cleared before write it's new AccessKey & SecretKey.
for examble:
*****:******xxxx
***is new AccessKey & SecretKey. And xxxx is part of old AccessKey & SecretKey.

Use os.O_TRUNC to clear .passwd-s3fs before write new AccessKey & SecretKey.