### PR TITLE
Add correct DNSPolicy to csi-s3 daemonset

### DIFF
--- a/deploy/kubernetes/csi-s3.yaml
+++ b/deploy/kubernetes/csi-s3.yaml
@@ -54,6 +54,7 @@ spec:
     spec:
       serviceAccount: csi-s3
       hostNetwork: true
+      dnsPolicy: "ClusterFirstWithHostNet"
       containers:
         - name: driver-registrar
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0


### PR DESCRIPTION
Please refer to issue #51 
This PR fixes the DNS problems found when trying to query internal services with the default k8s hostnames (coreDNS).
When using Demonsets with hostNetwork = true, we should add the dnsPolicy "ClusterFirstWithHostNet". Although, we cannot access to the Cluster DNS service
https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
https://github.com/kubernetes/kubernetes/issues/17406

